### PR TITLE
Change file type content

### DIFF
--- a/app/views/funding/grant/reports/data-sets/upload.html
+++ b/app/views/funding/grant/reports/data-sets/upload.html
@@ -19,8 +19,10 @@
 
     <p class="govuk-body">Check the <a class="govuk-link" href="">grant recipients</a> have been set up before uploading a data set. The grant recipients will be reflected in the <a class="govuk-link" href="">data set template (CSV)</a>.
     </p> 
+
+    <!-- <p class="govuk-body">You can replace any uploaded data set.</p> -->
     
-    <p class="govuk-body">Missing or incorrect data can be replaced later.</p>
+    <!-- <p class="govuk-body">Missing or incorrect data can be replaced later.</p> -->
 
     <div class="govuk-form-group">
       <label class="govuk-label" for="event-name">
@@ -44,7 +46,7 @@
       </div>
     </div>
 
-    <details class="govuk-details">
+    <!-- <details class="govuk-details">
       <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text">
           What file types can I upload?
@@ -59,7 +61,11 @@
     </ul>
     
       </div>
-    </details> 
+    </details>  -->
+
+    <p class="govuk-body">
+      Only CSV (.csv) files can be uploaded for data sets.
+    </p>
 
     <br>
     <form method="post" action="map">


### PR DESCRIPTION
Swapping out the standard details component we use for file upload with a single line of text because we only allow one type. Opting for conciseness over consistency here, to review with team and users.

File upload with multiple file types allowed
<img width="838" height="820" alt="File upload with multiple file types allowed" src="https://github.com/user-attachments/assets/32f1d9f2-ccb4-4c1d-acad-d186bf6a9911" />

Data set file upload with one file type allowed
<img width="1053" height="594" alt="Data set file upload with one file type allowed" src="https://github.com/user-attachments/assets/f3e2f0c7-1f29-4c87-b939-b254ab1be2ae" />



