### PR TITLE
Update success and view data set content

### DIFF
--- a/app/views/funding/grant/reports/data-sets/upload-success.html
+++ b/app/views/funding/grant/reports/data-sets/upload-success.html
@@ -4,7 +4,7 @@
 {% set showBackLink = false %}
 
 {% set pageSize = "l" %}
-{% set pageHeading = "Reports" %}
+{% set pageHeading = "Uploaded data sets - Reports" %}
 {% set pageSection = '' + data['grantName'] + '' %}
 {% set pageHiddentext = "yes" %}
 {% set pageNested = "yes" %}
@@ -32,9 +32,9 @@ items: [
       </div>
       <div class="govuk-notification-banner__content">
         <h3 class="govuk-notification-banner__heading">
-          Outputs data set uploaded
+          Grant allocation data set uploaded
         </h3>
-        <p class="govuk-body">You can now reference Outputs data in the 1 April 2026 to 30 June 2026 grant form. <a
+        <p class="govuk-body">You can now reference Grant allocation data in the Mid-year monitoring form. <a
             class="govuk-link" href="view-data-set">View data set</a></p>
       </div>
     </div>
@@ -43,6 +43,10 @@ items: [
 <span class="govuk-caption-l">Mid-year monitoring</span>
 <h1 class="govuk-heading-l">Uploaded data sets</h1>
 
+<p class="govuk-body">Upload data to reference in guidance, questions, conditions and validation.</p>
+
+<p class="govuk-body">You can replace uploaded data sets to update missing or incorrect data.</p>
+
  <details class="govuk-details">
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
@@ -50,12 +54,12 @@ items: [
     </span>
   </summary>
   <div class="govuk-details__text">
+
 <ol class="govuk-list govuk-list--number">
-  <li><a class="govuk-link" href="">Check the grant recipients have been set up</a></li>
-  <li><a class="govuk-link" href="">Download the data set template (CSV)</li></a> with grant recipients listed</li>
-  <li>Name the columns to describe the data in it, for example, "Funding"</li>
-  <li>Add the data to the CSV</li>
-  <li>Format the data columns and upload the data set</li>
+  <li>Check the <a class="govuk-link" href="">grant recipients</a> are set up to make sure they will be in the data set template.</li>
+  <li><a class="govuk-link" href="">Download the data set template (CSV).</li></a></li>
+  <li>Name each column to describe the data in it, for example, "Funding".</li>
+  <li>Upload the new data set by naming and formatting the data set.</li>
 </ol>
 
   </div>
@@ -79,13 +83,13 @@ items: [
   </thead>
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
-          <td class="govuk-table__cell"><a class="govuk-link" href="">Grant allocations</a></td>
+          <td class="govuk-table__cell"><a class="govuk-link" href="view-data-set.html">Grant allocations</a></td>
           <!-- <td class="govuk-table__cell">Grant allocations</td> -->
           <td class="govuk-table__cell">
-            20 May 2026 at 3:41pm
+            10 May 2026 at 3:41pm
           </td>
 
-          <td class="govuk-table__cell">Connie Smith</td>
+          <td class="govuk-table__cell">Tom Owen</td>
 
           <!-- <td class="govuk-table__cell"><a class="govuk-link" href="">View</a></td> -->
         </tr>

--- a/app/views/funding/grant/reports/data-sets/view-data-set.html
+++ b/app/views/funding/grant/reports/data-sets/view-data-set.html
@@ -49,7 +49,7 @@ items: [
               Date and time uploaded
             </dt>
             <dd class="govuk-summary-list__value">
-              20 May 2026 at 10:08am
+              10 May 2026 at 3:41pm
             </dd>
           </div>
 
@@ -57,11 +57,11 @@ items: [
 
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
-              Uploaded data set
+              Uploaded file
             </dt>
             <dd class="govuk-summary-list__value">
-              SSHF_Q1_26_outputs_data_v1.csv
-              <br> <a href="" class="govuk-link">Download data set (CSV &ndash; 100KB)<span
+              Q1_26_grant_allocation_data_v1.csv
+              <br> <a href="" class="govuk-link">Download uploaded file (CSV &ndash; 100KB)<span
                   class="govuk-visually-hidden"> grant recipient</span></a>
             </dd>
           </div>


### PR DESCRIPTION
Update successful data set upload page with:
- scenario data set name and report name in confirmation banner
- add view data set link to Grant allocation link in table
- guidance updates from no data sets page

Update view data set page to specify uploaded file/download uploaded file link