### PR TITLE
Update sign in page content

### DIFF
--- a/app/views/user-admin/sign-in.html
+++ b/app/views/user-admin/sign-in.html
@@ -41,14 +41,6 @@
       A service for organisations to complete and submit forms for central government grants.
     </p>
 
-    <p class="govuk-body">
-      If you do not have access, you can <a href="" class="govuk-link">request access</a>.
-    </p>
-
-    <p class="govuk-body">
-      If you know someone with access, they can add you from the Team page in Access grant funding.
-    </p>
-
             <form method="post" action="email-sent" >
                 {{ govukInput({
                     label: {
@@ -63,13 +55,20 @@
                 }) }}
 
                 {{ govukButton({
-                    text: "Request sign in link"
+                    text: "Sign in with link"
                 }) }}
             </form>
 
         {% endif %}
 
+    <h3 class="govuk-heading-m">If you need access</h3>
+
+            <p class="govuk-body">
+      You can <a href="" class="govuk-link">request access</a> or ask someone you know to add you from the Team page.
+    </p>
+
     </div>
+
 </div>
 
 {% endblock %}


### PR DESCRIPTION
Update following user research to:
- differentiate the primary button language for sign in from 'Request sign in link' to 'Sign in with link'
- move request access link content under the primary button under a subheading

Before
<img width="1916" height="989" alt="Screenshot 2026-08-18 at 13 25 41" src="https://github.com/user-attachments/assets/fe76c70a-274f-4a79-8a7c-14b745cd1c53" />

After 
<img width="1292" height="842" alt="Screenshot 2026-08-18 at 13 31 40" src="https://github.com/user-attachments/assets/abb0d79a-d62b-4907-98e5-d5d41e3e910c" />
