### PR TITLE
Add action column to Form and Team pages

### DIFF
--- a/app/views/user-admin/dashboard.html
+++ b/app/views/user-admin/dashboard.html
@@ -33,7 +33,7 @@ View and complete forms relating to grant funding. These may include forms to ap
           <th scope="col" class="govuk-table__header">Forms</th>
           <th scope="col" class="govuk-table__header">Due date</th>
           <th scope="col" class="govuk-table__header">Status</th>
-          <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Action</span></th>
+          <th scope="col" class="govuk-table__header">Action</th>
         </tr>
       </thead>
       <tbody class="govuk-table__body">

--- a/app/views/user-admin/team.html
+++ b/app/views/user-admin/team.html
@@ -30,7 +30,7 @@ Add team member
           <th scope="col" class="govuk-table__header">Name</th>
           <th scope="col" class="govuk-table__header">Email address</th>
           <th scope="col" class="govuk-table__header">Permissions</th>
-          <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Action</span></th>
+          <th scope="col" class="govuk-table__header">Action</th>
         </tr>
       </thead>
       <tbody class="govuk-table__body">


### PR DESCRIPTION
Add 'Action' column heading for columns in Forms page and Team page

Forms page with Action column for viewing and continuing forms
<img width="1320" height="907" alt="Screenshot 2026-08-18 at 13 53 51" src="https://github.com/user-attachments/assets/70419458-5890-4b51-8c2d-829bde561328" />

Teams page with Action column for removing team members
<img width="1198" height="931" alt="Screenshot 2026-08-18 at 13 53 44" src="https://github.com/user-attachments/assets/e4237406-eb9a-41aa-95cf-342f00faaaa2" />
