### PR TITLE
Change other email domain content

### DIFF
--- a/app/views/user-admin/other_domain.html
+++ b/app/views/user-admin/other_domain.html
@@ -16,12 +16,17 @@
       Confirm Sharon Plumpton's email address
     </h1>
 
+        
+  <p class="govuk-body">
+      Email addresses for Hastings Borough Council usually end in @hastings.gov.uk
+    </p>
+
     <p class="govuk-body">
-      We noticed Sharon Plumpton's email address is different from other team members' in your organisation:
+      We noticed this email address does not match your organisation's usual format:
     </p>
 
     <div class="govuk-inset-text">
-      Sharon Plumpton (splumpton@lewes-eastbourne.gov.uk)
+      splumpton@lewes-eastbourne.gov.uk
     </div>
 
     <form action="" method="post" novalidate>


### PR DESCRIPTION
Updating the page users see when adding someone to a local authority with a different email domain to the organisation's usual email domain.

User feedback was that the original content suggested emails were being checked against individual user emails rather than the email associated with the organisation. 

Before
<img width="2902" height="1678" alt="image (96)" src="https://github.com/user-attachments/assets/5cbde76a-a0fc-4416-b5a1-e750accccc41" />

After
<img width="1244" height="827" alt="Screenshot 2026-08-18 at 14 10 11" src="https://github.com/user-attachments/assets/4793ffff-b2d2-4971-a9e5-f7a883405e00" />
