### PR TITLE
Update invitation email content

### DIFF
--- a/app/views/user-admin/email-added.html
+++ b/app/views/user-admin/email-added.html
@@ -31,7 +31,7 @@
               <tr class="email-message-meta">
                 <th class="govuk-table__cell" scope="row">Subject</th>
 
-            <td class="govuk-table__cell">You can sign in to Access grant funding</td>
+            <td class="govuk-table__cell">You've been invited to Access grant funding</td>
 
 
               </tr>
@@ -41,7 +41,9 @@
 
       <p>Hello,</p>
   
-      <p>You now have access to Hastings Borough Council's Safer social housing fund.</p>
+      <p>You've been invited to Hastings Borough Council's Safer social housing fund.</p>
+
+      <p>This invitation expires in 7 days.</p>
 
       <p><a href="#">Sign in to Access grant funding</a></p>
 


### PR DESCRIPTION
Update invitation email for users invited to Access grant funding to:
- change language from sounding like guaranteed access to reflect the actual invitation model — accounts are not created until the user signs in using the invitation email link
- communicating the invitation's expiry in 7 days

Before
<img width="2902" height="1886" alt="image (98)" src="https://github.com/user-attachments/assets/122d6014-4d97-4384-9a77-60c98ebb475c" />


After
<img width="1369" height="979" alt="Screenshot 2026-08-18 at 14 43 33" src="https://github.com/user-attachments/assets/2aa55618-ff7e-49d1-a150-89494db329fc" />
