### PR TITLE
Update existing user page

### DIFF
--- a/app/views/user-admin/existing_user.html
+++ b/app/views/user-admin/existing_user.html
@@ -15,13 +15,13 @@
     <h1 class="govuk-heading-l">
       This team member already has access
     </h1>
-
+<!-- 
     <div class="govuk-inset-text">
       {{ data['emailAddress'] or "sboyle@hastings.gov.uk" }} 
-    </div>
+    </div> -->
 
     <p class="govuk-body">
-       {{ data['fullName'] or "Shayne Boyle" }} already has access to this grant.
+       {{ data['fullName'] or "Shayne Boyle" }} ({{ data['emailAddress'] or "sboyle@hastings.gov.uk" }}) already has access to this grant.
     </p>
 
     <form action="add_user" method="post" novalidate>


### PR DESCRIPTION
Removing unnecessary email in inset text/fixing disjointed content between separate email and sentence communicating that the user already has access.

Before
<img width="2902" height="1858" alt="image (99)" src="https://github.com/user-attachments/assets/4ce47d8d-4c93-4986-b72f-8faa7031296a" />


After 
<img width="1344" height="821" alt="Screenshot 2026-08-18 at 17 41 14" src="https://github.com/user-attachments/assets/05ec60bd-ba40-4002-8680-d335933dc28b" />
