### PR TITLE
Remove request access from sign in page

### DIFF
--- a/app/views/user-admin/sign-in.html
+++ b/app/views/user-admin/sign-in.html
@@ -64,7 +64,7 @@
     <h3 class="govuk-heading-m">If you need access</h3>
 
             <p class="govuk-body">
-      You can <a href="" class="govuk-link">request access</a> or ask someone to add you from the Team page.
+      You can ask someone to add you from the Team page or <a href="" class="govuk-link">request access using the support desk (opens in new tab)</a>.
     </p>
 
     </div>


### PR DESCRIPTION
Removing the link to the request access journey as we are deprioritising this build for now. Users should continue to be directed to the support desk for any access requests for themselves.

Before
<img width="1457" height="858" alt="image - 2026-08-28T094708 716" src="https://github.com/user-attachments/assets/aebe6a9e-916f-42b9-91de-a95c10f513e8" />

After 
<img width="1770" height="944" alt="Screenshot 2026-08-28 at 09 47 25" src="https://github.com/user-attachments/assets/6dff63c6-9a77-4922-802e-27559fefb381" />
